### PR TITLE
Change SSRF attack payload

### DIFF
--- a/cli/attacks/ssrf.js
+++ b/cli/attacks/ssrf.js
@@ -70,7 +70,7 @@ async function exploit(targetURL){
     let info = await createAndLogin(targetURL)
 
     await new Promise(r => setTimeout(r, 2000));
-    payload = "https://ojqweoim23edjkl2ndo23mdi203dm23.burpcollaborator.net:443/"
+    payload = "ojqweoim23edjkl2ndo23mdi203dm23.burpcollaborator.net"
     spinner.text = 'Successful SSRF Injection: ' + payload;
 
     const form = new FormData();
@@ -95,7 +95,7 @@ async function exploit(targetURL){
     await new Promise(r => setTimeout(r, 1000));
     spinner.stopAndPersist({
         symbol: logSymbols.success,
-        text: 'Successful SQL injection attack - done',
+        text: 'Successful SSRF injection attack - done',
     });
 
     


### PR DESCRIPTION
### What does this PR do?

Changes the payload for SSRF exploit

### Motivation

The current payload is not detected as `SSRF` exploit.

If the `params` address sent to WAF contains the protocol part, it is not detected as exploitable:

**Not Exploitable**
```
server.request.query = { host: 'http://localhost/ifconfig.pro' }
server.io.net.url = 'http://localhost/ifconfig.pro'
```

but if the `params` address sent to WAF doesn't contain the protocol, and the protocol is added later by the application (so the resource address has it), it is detected as exploitable.

**Exploitable**
```
server.request.query = { host: 'localhost/ifconfig.pro' }
server.io.net.url = 'http://localhost/ifconfig.pro'
```

### Checklist
- [**N/A**] The attack emulates a single threat and trigger as few signals as possible
- [**N/A**] The documentation was updated to describe the attack and explain its relevancy

### Additional notes
Juice shop PR: https://github.com/DataDog/juice-shop/pull/10

[APPSEC-55229](https://datadoghq.atlassian.net/browse/APPSEC-55229)

[APPSEC-55229]: https://datadoghq.atlassian.net/browse/APPSEC-55229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ